### PR TITLE
Version 6.0 it's ready 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _Here you have an index of all the features, completed and future ones, on each 
     * updateTask
     * deleteDask
   * Implement of a login functionality in API Platform
-* Version 6.0 🔜 ***Work In progress***
+* Version 6.0 ✅ ***Released!***
   * Add a custom [Symfony Form](https://symfony.com/doc/current/forms.html) to transfer task to another user
   * This form must be accessible from the task level, next to the task. (Extend from EasyAdmin)
   * The action of transfer a task must meet the following objectives
@@ -55,6 +55,8 @@ _Here you have an index of all the features, completed and future ones, on each 
     * Task marked as finished can't be transferred
     * To transfer the task to another user, the receiver one can't have more than three active task
     * A task can't be transferred more than two times
+* Version 7.0 🔜 ***Work In progress***
+  * ¿?
 
 ## Author ✒️
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0a6a0ed3dd64046dd78e383da558952",
+    "content-hash": "902d00cdb71633967098fcfd257ca63f",
     "packages": [
         {
             "name": "api-platform/core",
@@ -8042,16 +8042,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.3.3",
+            "version": "v3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a27fa056df8a6384316288ca8b0fa3a35fdeb569"
+                "reference": "65cb6f0b956485e1664f13d023c55298a4bb59ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a27fa056df8a6384316288ca8b0fa3a35fdeb569",
-                "reference": "a27fa056df8a6384316288ca8b0fa3a35fdeb569",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/65cb6f0b956485e1664f13d023c55298a4bb59ca",
+                "reference": "65cb6f0b956485e1664f13d023c55298a4bb59ca",
                 "shasum": ""
             },
             "require": {
@@ -8102,7 +8102,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.3.3"
+                "source": "https://github.com/twigphp/Twig/tree/v3.3.4"
             },
             "funding": [
                 {
@@ -8114,7 +8114,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-17T08:44:23+00:00"
+            "time": "2021-11-25T13:46:55+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -8689,23 +8689,23 @@
         },
         {
             "name": "twig/extra-bundle",
-            "version": "v3.3.3",
+            "version": "v3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/twig-extra-bundle.git",
-                "reference": "fa92b8301ff8878e45fe9f54ab7ad99872e080f3"
+                "reference": "1fe52d84aa22b7891c7717ef904b1551c8d70100"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/fa92b8301ff8878e45fe9f54ab7ad99872e080f3",
-                "reference": "fa92b8301ff8878e45fe9f54ab7ad99872e080f3",
+                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/1fe52d84aa22b7891c7717ef904b1551c8d70100",
+                "reference": "1fe52d84aa22b7891c7717ef904b1551c8d70100",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3|^8.0",
-                "symfony/framework-bundle": "^4.3|^5.0|^6.0",
-                "symfony/twig-bundle": "^4.3|^5.0|^6.0",
-                "twig/twig": "^2.4|^3.0"
+                "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+                "symfony/twig-bundle": "^4.4|^5.0|^6.0",
+                "twig/twig": "^2.7|^3.0"
             },
             "require-dev": {
                 "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
@@ -8751,7 +8751,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/twigphp/twig-extra-bundle/tree/v3.3.3"
+                "source": "https://github.com/twigphp/twig-extra-bundle/tree/v3.3.4"
             },
             "funding": [
                 {
@@ -8763,7 +8763,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-20T14:28:34+00:00"
+            "time": "2021-11-13T16:20:21+00:00"
         }
     ],
     "aliases": [],
@@ -8772,7 +8772,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2.5",
+        "php": ">=7.4",
         "ext-ctype": "*",
         "ext-iconv": "*"
     },

--- a/migrations/Version20211129084240.php
+++ b/migrations/Version20211129084240.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211129084240 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tareas ADD veces_transferida INT NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649F85E0677 ON user (username)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tareas DROP veces_transferida');
+        $this->addSql('DROP INDEX UNIQ_8D93D649F85E0677 ON user');
+    }
+}

--- a/migrations/Version20211129085209.php
+++ b/migrations/Version20211129085209.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211129085209 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tareas ADD veces_transferida INT NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649F85E0677 ON user (username)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tareas DROP veces_transferida');
+        $this->addSql('DROP INDEX UNIQ_8D93D649F85E0677 ON user');
+    }
+}

--- a/src/Controller/Admin/TareasCrudController.php
+++ b/src/Controller/Admin/TareasCrudController.php
@@ -87,10 +87,16 @@ class TareasCrudController extends AbstractCrudController
 
     public function configureActions(Actions $actions): Actions
     {
+        $transferTask = Action::new('transferir_tareas', 'Transferir tarea')
+            ->setIcon('fas fa-exchange-alt')
+            ->linkToRoute('transferir_tareas');
+
         return $actions
             ->add(Crud::PAGE_INDEX, Action::DETAIL)
             ->add(Crud::PAGE_EDIT, Action::SAVE_AND_ADD_ANOTHER)
             ->remove(Crud::PAGE_DETAIL, ACTION:: DELETE)
+            ->add(Crud::PAGE_INDEX, $transferTask)
+            ->add(Crud::PAGE_DETAIL, $transferTask)
 
             ;
     }

--- a/src/Controller/Admin/TareasCrudController.php
+++ b/src/Controller/Admin/TareasCrudController.php
@@ -2,9 +2,11 @@
 
 namespace App\Controller\Admin;
 
+use App\Entity\Tarea;
 use App\Entity\Tareas;
 
 use App\Repository\TareasRepository;
+use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
@@ -12,6 +14,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\BooleanFilter;
@@ -26,6 +29,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
+use http\Env\Request;
 
 
 class TareasCrudController extends AbstractCrudController
@@ -58,6 +62,8 @@ class TareasCrudController extends AbstractCrudController
                         ->setParameter('user', $this->getUser()->getUserIdentifier());
                 }])->hideOnForm()->hideOnDetail()->hideOnIndex(),
 
+            IntegerField::new("vecesTransferida")->hideOnForm(),
+
             DateTimeField::new('creada')->hideOnForm()
         ];
     }
@@ -87,9 +93,10 @@ class TareasCrudController extends AbstractCrudController
 
     public function configureActions(Actions $actions): Actions
     {
-        $transferTask = Action::new('transferir_tareas', 'Transferir tarea')
+        $transferTask = Action::new('taskTransfer', 'Transferir tarea')
             ->setIcon('fas fa-exchange-alt')
-            ->linkToRoute('transferir_tareas');
+            ->linkToCrudAction('extraerIdTarea')
+            ->displayIf(fn (Tareas $tarea) => ($tarea->getRealizada() == false) && ($tarea->getVecesTransferida() < 2));;
 
         return $actions
             ->add(Crud::PAGE_INDEX, Action::DETAIL)
@@ -107,5 +114,18 @@ class TareasCrudController extends AbstractCrudController
             ->showEntityActionsInlined(true)
             ->setPageTitle('detail', fn (Tareas $tareas) => sprintf($tareas->getTitulo()))
             ;
+    }
+
+
+    public function extraerIdTarea(AdminContext $context)
+    {
+        $id     = $context->getRequest()->query->get('entityId');
+        $tareas = $this->getDoctrine()->getRepository(Tareas::class)->find($id);
+        $end     = $tareas->getRealizada();
+
+        $end = $end ? 'true' : 'false';
+
+        return $this->redirectToRoute('taskTransfer', array('id' => $id, 'end' => $end));
+
     }
 }

--- a/src/Controller/TransferirTareasController.php
+++ b/src/Controller/TransferirTareasController.php
@@ -2,9 +2,12 @@
 
 namespace App\Controller;
 
+use App\Entity\Tareas;
 use App\Entity\User;
 use App\Form\TaskTransferFormType;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -12,30 +15,89 @@ use Symfony\Component\Routing\Annotation\Route;
 class TransferirTareasController extends AbstractController
 {
     /**
-     * @Route("/transferir/tareas", name="transferir_tareas")
+     * @Route("/taskTransfer/{id}/{end}", name="taskTransfer")
      */
-    public function new(Request $request): Response
+    public function transfer(Request $request): Response
     {
-
         $form = $this->createForm(TaskTransferFormType::class);
 
         if ($request->isMethod('POST')) {
 
             $form->submit($request->request->get($form->getName()));
+
+
             if ($form->isSubmitted() && $form->isValid()) {
-                // $form->getData() holds the submitted values
-                // but, the original `$task` variable has also been updated
+
                 $user = $form->getData();
 
-                // ... perform some action, such as saving the task to the database
-                // for example, if Task is a Doctrine entity, save it!
-                $entityManager = $this->getDoctrine()->getManager()->getRepository('App:User')->findOneBy(array('username' => $user['username']));
+                $comprobar = $this->getDoctrine()->getManager()->getRepository('App:User')->findOneBy(array('email' => $user['username']));
 
-                return $this->redirectToRoute('admin');
+                if ($comprobar != NULL) {
+
+                    // Obteniendo el id del usuario:
+
+                    $id = $comprobar->getId();
+
+                    // Hago esta consulta: SELECT count(*) FROM tareas WHERE id_usuario_id = 1 AND realizada = 0;
+
+                    $q = $this->getDoctrine()->getManager()->getRepository('App:Tareas')->createQueryBuilder('tareas')
+                        ->select('count(tareas.id)')
+                        ->where('tareas.user = :id')
+                        ->andWhere('tareas.realizada = false')
+                        ->setParameter('id', $id)
+                        ->getQuery()->getResult();
+
+                    // Asigno a $q la cantidad de tareas sin completar que tiene el usuario
+
+                    $q = $q[0][1];
+
+                    if ($user['username'] === $comprobar->getUsername() && $request->attributes->get('end') == 'false' && $q < 3) {
+
+                        // Compruebo que la tarea no ha sido transferida mas de 2 veces
+
+                        $veces = $this->getDoctrine()->getManager()->getRepository('App:Tareas')->createQueryBuilder('tareas')
+                            ->select('tareas.vecesTransferida')
+                            ->where('tareas.id = '.$request->attributes->get('id'))
+                            ->getQuery()->getResult();
+
+                        $veces = $veces[0]['vecesTransferida'];
+
+                        if ($veces < 2) {
+
+                            $sumarVez = $this->getDoctrine()->getManager()->getRepository('App:Tareas')->createQueryBuilder('tareas')
+                                ->update('App:Tareas', 'tareas')
+                                ->set('tareas.vecesTransferida', 'tareas.vecesTransferida + 1')
+                                ->where('tareas.id = ' .$request->attributes->get('id'))
+                                ->getQuery()->getResult();
+
+                            $cambiarTarea = $this->getDoctrine()->getManager()->getRepository('App:Tareas')->createQueryBuilder('tareas')
+                                ->update('App:Tareas', 'tareas')
+                                ->set('tareas.user', $id)
+                                ->where('tareas.id = ' . $request->attributes->get('id'))
+                                ->getQuery()->getResult();
+
+                            return $this->redirectToRoute('admin');
+
+
+                        } else {
+
+                            $form->addError(new FormError("La tarea ha sido transferida dos veces o más veces."));
+                        }
+
+                    } else {
+
+                        $form->addError(new FormError("La tarea está completada o el usuario tiene más de 3 tareas pendientes."));
+                    }
+
+                } else {
+
+                    $form->addError(new FormError("Usuario no encontrado."));
+
+                }
             }
         }
 
-        return $this->render('tranferir_tareas/index.html.twig', [
+        return $this->render('taskTransfer/taskTransfer.html.twig', [
             'taskTransferForm' => $form->createView(),
         ]);
     }

--- a/src/Controller/TransferirTareasController.php
+++ b/src/Controller/TransferirTareasController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Form\TaskTransferFormType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class TransferirTareasController extends AbstractController
+{
+    /**
+     * @Route("/transferir/tareas", name="transferir_tareas")
+     */
+    public function new(Request $request): Response
+    {
+
+        $form = $this->createForm(TaskTransferFormType::class);
+
+        if ($request->isMethod('POST')) {
+
+            $form->submit($request->request->get($form->getName()));
+            if ($form->isSubmitted() && $form->isValid()) {
+                // $form->getData() holds the submitted values
+                // but, the original `$task` variable has also been updated
+                $user = $form->getData();
+
+                // ... perform some action, such as saving the task to the database
+                // for example, if Task is a Doctrine entity, save it!
+                $entityManager = $this->getDoctrine()->getManager()->getRepository('App:User')->findOneBy(array('username' => $user['username']));
+
+                return $this->redirectToRoute('admin');
+            }
+        }
+
+        return $this->render('tranferir_tareas/index.html.twig', [
+            'taskTransferForm' => $form->createView(),
+        ]);
+    }
+}

--- a/src/Entity/Tareas.php
+++ b/src/Entity/Tareas.php
@@ -75,6 +75,11 @@ class Tareas
      */
     private $creada;
 
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $vecesTransferida;
+
 
     public function __construct()
     {
@@ -172,6 +177,18 @@ class Tareas
     public function setCreada(\DateTimeInterface $creada): self
     {
         $this->creada = $creada;
+
+        return $this;
+    }
+
+    public function getVecesTransferida(): ?int
+    {
+        return $this->vecesTransferida;
+    }
+
+    public function setVecesTransferida(?int $vecesTransferida): self
+    {
+        $this->vecesTransferida = $vecesTransferida;
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -14,6 +14,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 /**
  * @ORM\Entity(repositoryClass=UserRepository::class)
  * @UniqueEntity(fields={"email"}, message="There is already an account with this email")
+ * @UniqueEntity(fields={"username"}, message="There is already an account with this username")
  * @ApiResource()
  */
 class User implements UserInterface, PasswordAuthenticatedUserInterface

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -86,7 +86,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function getUserIdentifier(): string
     {
-        return (string)$this->username;
+        return (string)$this->email;
     }
 
     /**

--- a/src/EventSubscriber/VecesTransferidaSubscriber.php
+++ b/src/EventSubscriber/VecesTransferidaSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Entity\Tareas;
+use EasyCorp\Bundle\EasyAdminBundle\Event\BeforeEntityPersistedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Security;
+
+class VecesTransferidaSubscriber implements EventSubscriberInterface
+{
+
+    private $security;
+
+    public function __construct(Security $security)
+    {
+        $this->security = $security;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            BeforeEntityPersistedEvent::class => ['setVecesTransferida'],
+        ];
+    }
+
+    public function setVecesTransferida(BeforeEntityPersistedEvent $event)
+    {
+        $entity = $event->getEntityInstance();
+
+        if (!($entity instanceof Tareas)) {
+            return;
+        }
+
+        $transferida = 0;
+        $entity->setVecesTransferida($transferida);
+    }
+
+}

--- a/src/Form/TaskTransferFormType.php
+++ b/src/Form/TaskTransferFormType.php
@@ -2,8 +2,8 @@
 
 namespace App\Form;
 
-use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -12,7 +12,7 @@ class TaskTransferFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('username')
+            ->add('username', TextType::class, ['label' => 'Email del usuario que recibira la tarea: ']);
         ;
     }
 

--- a/src/Form/TaskTransferFormType.php
+++ b/src/Form/TaskTransferFormType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TaskTransferFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('username')
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+        ]);
+    }
+}

--- a/templates/taskTransfer/taskTransfer.html.twig
+++ b/templates/taskTransfer/taskTransfer.html.twig
@@ -11,9 +11,8 @@
 
     <h1 class="h3 mb-3 font-weight-normal">Tranferencia de una tarea</h1>
     {{ form_start(taskTransferForm) }}
-    {{ form_row(taskTransferForm.username, {
-        label: 'Usuario a transferir'
-    }) }}
+    {{ form_row(taskTransferForm.username) }}
+    {{ form_errors(taskTransferForm) }}
 
     <a href="{{ path('admin') }}">Volver a las tareas</a>
     <br/>

--- a/templates/tranferir_tareas/index.html.twig
+++ b/templates/tranferir_tareas/index.html.twig
@@ -1,0 +1,24 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Task Transfer{% endblock %}
+
+{% block body %}
+    {% if app.user %}
+        <div class="mb-3">
+            Vas a tranferir una tarea desde <b>{{ app.user.username }}</b></a>
+        </div>
+    {% endif %}
+
+    <h1 class="h3 mb-3 font-weight-normal">Tranferencia de una tarea</h1>
+    {{ form_start(taskTransferForm) }}
+    {{ form_row(taskTransferForm.username, {
+        label: 'Usuario a transferir'
+    }) }}
+
+    <a href="{{ path('admin') }}">Volver a las tareas</a>
+    <br/>
+    <button class="btn btn-lg btn-primary" type="submit">
+        Transferir
+    </button>
+    {{ form_end(taskTransferForm) }}
+{% endblock %}


### PR DESCRIPTION
Version 6.0 has implemented the following:  

* Add a custom [Symfony Form](https://symfony.com/doc/current/forms.html) to transfer task to another user
  * This form must be accessible from the task level, next to the task. (Extend from EasyAdmin)
  * The action of transfer a task must meet the following objectives
    * All users can transfer their task to another user
    * Task marked as finished can't be transferred
    * To transfer the task to another user, the receiver one can't have more than three active task
    * A task can't be transferred more than two times